### PR TITLE
Simplify `__len__` method to use index length

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [pypi-v-link]: https://pypi.org/project/xlviews/
 [python-v-image]: https://img.shields.io/pypi/pyversions/xlviews.svg
 [python-v-link]: https://pypi.org/project/xlviews
-[GHAction-image]: https://github.com/daizutabi/xlviews/actions/workflows/ci.yml/badge.svg?branch=main&event=push
+[GHAction-image]: https://github.com/daizutabi/xlviews/actions/workflows/ci.yaml/badge.svg?branch=main&event=push
 [GHAction-link]: https://github.com/daizutabi/xlviews/actions?query=event%3Apush+branch%3Amain
 [codecov-image]: https://codecov.io/github/daizutabi/xlviews/coverage.svg?branch=main
 [codecov-link]: https://codecov.io/github/daizutabi/xlviews?branch=main

--- a/src/xlviews/dataframes/sheet_frame.py
+++ b/src/xlviews/dataframes/sheet_frame.py
@@ -89,13 +89,7 @@ class SheetFrame:
         return str(self.expand()).replace("<Range ", "<SheetFrame ")
 
     def __len__(self) -> int:
-        start = self.cell.offset(self.columns.nlevels)
-        cell = start
-
-        while cell.value is not None:
-            cell = cell.expand("down")[-1].offset(1)
-
-        return cell.row - start.row
+        return len(self.index)
 
     @property
     def row(self) -> int:


### PR DESCRIPTION
- Replace manual row counting logic with a direct call to `len(self.index)`
- Align `__len__` method with the recent refactoring of index handling in SheetFrame