### PR TITLE
Remove `wide_columns_past` method from SheetFrame

### DIFF
--- a/src/xlviews/dataframes/sheet_frame.py
+++ b/src/xlviews/dataframes/sheet_frame.py
@@ -137,13 +137,6 @@ class SheetFrame:
     def index_columns(self) -> list[str | tuple[str, ...] | None]:
         return self.headers[: self.index.nlevels]
 
-    @property
-    def wide_columns_past(self) -> list[str]:
-        start = self.row - 1, self.column + self.index.nlevels
-        end = start[0], start[1] + len(self.headers) - self.index.nlevels - 1
-        cs = self.sheet.range(start, end).value or []
-        return [c for c in cs if c]
-
     def __contains__(self, item: str | tuple) -> bool:
         return item in self.headers
 


### PR DESCRIPTION
Clean up unused method related to wide column handling after recent index and DataFrame refactoring