### PR TITLE
Add Colorbar to package exports

### DIFF
--- a/src/xlviews/__init__.py
+++ b/src/xlviews/__init__.py
@@ -1,6 +1,7 @@
 from xlviews.chart.axes import Axes
 from xlviews.chart.series import Series
 from xlviews.core.range import Range
+from xlviews.dataframes.colorbar import Colorbar
 from xlviews.dataframes.dist_frame import DistFrame
 from xlviews.dataframes.groupby import GroupBy
 from xlviews.dataframes.heat_frame import HeatFrame
@@ -10,6 +11,7 @@ from xlviews.utils import constant
 
 __all__ = [
     "Axes",
+    "Colorbar",
     "DistFrame",
     "GroupBy",
     "HeatFrame",


### PR DESCRIPTION
- Import Colorbar class in __init__.py
- Add Colorbar to __all__ list for easier package-level access